### PR TITLE
Update async-http-client from 1.9.0 -> 1.19.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.9.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.19.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
     ],
     targets: [


### PR DESCRIPTION
## What does this PR do?

Update  async-http-client to fix:
```
[961/962] Compiling Appwrite Client.swift
/usr/local/server/.build/checkouts/sdk-for-swift/Sources/Appwrite/Client.swift:40:83: error: type 'HTTPClient.EventLoopGroupProvider' has no member 'singleton'
    private static var eventLoopGroupProvider = HTTPClient.EventLoopGroupProvider.singleton
                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~~~~~~~~

/usr/src/code/src/Executor/Executor.php:96
#0 /usr/src/code/src/Appwrite/Platform/Workers/Builds.php(408): Executor\Executor-
```
